### PR TITLE
Remove "creates" attribute 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,8 +29,7 @@ docker_compose::params {
   } ->
   exec { 'move-docker-compose':
     command => 'mv /tmp/docker-compose /usr/local/bin',
-    user    => root,
-    creates => '/usr/local/bin/docker-compose'
+    user    => root
   } ->
   file { '/usr/local/bin/docker-compose':
     path  => '/usr/local/bin/docker-compose',


### PR DESCRIPTION
Remove "creates" attribute which will prevent the binary to be overwritten in case of an update. In my opinion the attribute is not necessary. 
