### PR TITLE
update default docker-compose to 1.5.2

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,7 +20,7 @@ class { 'docker_compose': }
 ```
 ```puppet
 class { 'docker_compose': 
-  version => '1.4.0'
+  version => '1.5.2'
 }
 ```
 
@@ -33,4 +33,4 @@ should return: `/usr/local/bin/docker-compose'
 ```sh
 docker-compose --version
 ```
-should return: `docker-compose version: 1.4.0`
+should return: `docker-compose version: 1.5.2`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@
 # Parameters:
 #
 # [*version*]
-#   The version of Docker Compose to be installed. Default is 1.4.0.
+#   The version of Docker Compose to be installed. Default is 1.5.2.
 #
 # Actions:
 #
@@ -15,7 +15,7 @@
 #   include 'docker_compose'
 #   class { 'docker_compose': }
 #   class { 'docker_compose':
-#     version => '1.4.0'
+#     version => '1.5.2'
 #   }
 #
 class docker_compose ($version = $docker_compose::params::version) inherits 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@
 #
 # Sample Usage:
 #
-class docker_compose::params ($version = '1.4.0') {
+class docker_compose::params ($version = '1.5.2') {
   Exec {
     path => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'] }
 }


### PR DESCRIPTION
updates the default version of docker-compose to the latest (1.5.2)
