### PR TITLE
change docker-compose to 0755 permissions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,6 @@ docker_compose::params {
     path  => '/usr/local/bin/docker-compose',
     owner => 'root',
     group => 'root',
-    mode  => '0775',
+    mode  => '0755',
   }
 }


### PR DESCRIPTION
Just tightening up security a bit. Want to make sure that user executing is actually logged in or executing as `root`, and not just a user of the group `root`. 
