### PR TITLE
added CentOS 6.6 to tested and supported OS's

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ Puppet module for downloading and installing [Docker Compose](https://docs.docke
 This module is currently tested on:
 
 * Ubuntu 15.04
-* CentOS 7.1
+* CentOS 6.6, 7.1
 
 It should also work on other Linux distros...
 

--- a/metadata.json
+++ b/metadata.json
@@ -14,8 +14,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
-        "6",
+        "6.6",
         "7"
       ]
     }


### PR DESCRIPTION
removed CentOS 5
