### PR TITLE
[khdevel_move-docker-compose_unless]

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,7 @@ class docker_compose (
   exec { 'move-docker-compose':
     command => "mv /tmp/docker-compose ${docker_compose_path}",
     user    => root,
-    creates => "${docker_compose_path}/docker-compose"
+    unless  => "[ $(${docker_version_cmd} | cut -d\",\" -f1 | cut -d\" \" -f3) = \"${version}\" ]",
   } ->
   file { "${docker_compose_path}/docker-compose":
     path  => "${docker_compose_path}/docker-compose",


### PR DESCRIPTION
Issue: there is not possible to update/downgrade a 'docker_compose'

Reason: the exec('move-docker-compose') cannot be run if a file '${docker_compose_path}/docker-compose' exists

Fix: change the 'creates' to 'unless' with the content liks in exec('download-docker-compose')
