### PR TITLE
Ensure curl is installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ class docker_compose (
   $docker_tmp          = $docker_compose::params::docker_tmp,
   $docker_compose_path = $docker_compose::params::docker_compose_path,) inherits 
 docker_compose::params {
-  # package { 'curl': ensure => 'installed' }
+  ensure_packages(['curl'], {'ensure' => 'installed'})
   if $docker_tmp != undef {
     $docker_version_cmd = "TMP=${docker_tmp} ${docker_compose_path}/docker-compose --version"
   } else {
@@ -34,6 +34,7 @@ docker_compose::params {
     user    => root,
     creates => '/tmp/bin/docker-compose',
     unless  => "[ $(${docker_version_cmd} | cut -d\",\" -f1 | cut -d\" \" -f3) = \"${version}\" ]",
+    require => Package['curl'],
   } ->
   exec { 'move-docker-compose':
     command => "mv /tmp/docker-compose ${docker_compose_path}",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,8 @@
 {
   "author": "Gary A. Stafford",
-  "dependencies": [],
+  "dependencies": [
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.2.0" }
+  ],
   "license": "Apache-2.0",
   "name": "garystafford-docker_compose",
   "operatingsystem_support": [


### PR DESCRIPTION
Currently, this module does not install curl when necessary. In fact,
the entry to install curl has been commented out.

    Error: Could not find command 'curl'
    Error: /Stage[main]/Docker_compose/Exec[download-docker-compose]/returns: change from notrun to 0 failed: Could not find command 'curl'
    Notice: /Stage[main]/Docker_compose/Exec[move-docker-compose]: Dependency Exec[download-docker-compose] has failures: true
    Warning: /Stage[main]/Docker_compose/Exec[move-docker-compose]: Skipping because of failed dependencies
    Notice: /Stage[main]/Docker_compose/File[/usr/local/bin/docker-compose]: Dependency Exec[download-docker-compose] has failures: true
    Warning: /Stage[main]/Docker_compose/File[/usr/local/bin/docker-compose]: Skipping because of failed dependencies

This commit ensures curl is installed using ensure_packages to avoid
conflicts because of duplicate declarations of the same package.